### PR TITLE
Handle empty script tags in availability parser

### DIFF
--- a/checkUrl.py
+++ b/checkUrl.py
@@ -53,11 +53,12 @@ def is_housing_available(html_content, url):
     # Check for availability in JSON data
     scripts = soup.find_all('script', type='application/json')
     for script in scripts:
-        if 'available' in script.string:
-            logger.info(f"Found JSON data for {url}: {script.string}")
-            if '"available":true' in script.string:
+        content = script.string
+        if content and 'available' in content:
+            logger.info(f"Found JSON data for {url}: {content}")
+            if '"available":true' in content:
                 return True
-            elif '"available":false' in script.string:
+            elif '"available":false' in content:
                 return False
     
     logger.warning(f"Could not determine availability for {url}")

--- a/tests/test_is_housing_available.py
+++ b/tests/test_is_housing_available.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from checkUrl import is_housing_available
+
+
+def test_is_housing_available_handles_empty_script():
+    html = "<html><body><script type='application/json'></script></body></html>"
+    assert is_housing_available(html, "http://example.com") is None


### PR DESCRIPTION
## Summary
- prevent `is_housing_available` from crashing when JSON script tags are empty
- add regression test for empty script handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e76ca67c832382a8b74d1eefcd7a